### PR TITLE
Add a Value() function to optional types

### DIFF
--- a/internal/edgedbtypes/bool.go
+++ b/internal/edgedbtypes/bool.go
@@ -38,6 +38,9 @@ type OptionalBool struct {
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalBool) Get() (bool, bool) { return o.val, o.isSet }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalBool) Value() bool { return o.val }
+
 // Set sets the value.
 func (o *OptionalBool) Set(val bool) {
 	o.val = val

--- a/internal/edgedbtypes/bytes.go
+++ b/internal/edgedbtypes/bytes.go
@@ -36,6 +36,9 @@ type OptionalBytes struct {
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalBytes) Get() ([]byte, bool) { return o.val, o.isSet }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalBytes) Value() []byte { return o.val }
+
 // Set sets the value.
 func (o *OptionalBytes) Set(val []byte) {
 	if val == nil {

--- a/internal/edgedbtypes/datetime.go
+++ b/internal/edgedbtypes/datetime.go
@@ -87,6 +87,9 @@ func (o OptionalDateTime) Get() (time.Time, bool) {
 	return o.val, o.isSet
 }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalDateTime) Value() time.Time { return o.val }
+
 // Set sets the value.
 func (o *OptionalDateTime) Set(val time.Time) {
 	o.val = val
@@ -182,6 +185,9 @@ func (o OptionalLocalDateTime) Get() (LocalDateTime, bool) {
 	return o.val, o.isSet
 }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalLocalDateTime) Value() LocalDateTime { return o.val }
+
 // Set sets the value.
 func (o *OptionalLocalDateTime) Set(val LocalDateTime) {
 	o.val = val
@@ -269,6 +275,9 @@ type OptionalLocalDate struct {
 
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalLocalDate) Get() (LocalDate, bool) { return o.val, o.isSet }
+
+// Value returns the value or the zero value if not set.
+func (o OptionalLocalDate) Value() LocalDate { return o.val }
 
 // Set sets the value.
 func (o *OptionalLocalDate) Set(val LocalDate) {
@@ -377,6 +386,9 @@ type OptionalLocalTime struct {
 
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalLocalTime) Get() (LocalTime, bool) { return o.val, o.isSet }
+
+// Value returns the value or the zero value if not set.
+func (o OptionalLocalTime) Value() LocalTime { return o.val }
 
 // Set sets the value.
 func (o *OptionalLocalTime) Set(val LocalTime) {
@@ -697,6 +709,9 @@ type OptionalDuration struct {
 
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalDuration) Get() (Duration, bool) { return o.val, o.isSet }
+
+// Value returns the value or the zero value if not set.
+func (o OptionalDuration) Value() Duration { return o.val }
 
 // Set sets the value.
 func (o *OptionalDuration) Set(val Duration) {
@@ -1102,6 +1117,9 @@ func (o OptionalRelativeDuration) Get() (RelativeDuration, bool) {
 	return o.val, o.isSet
 }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalRelativeDuration) Value() RelativeDuration { return o.val }
+
 // Set sets the value.
 func (o *OptionalRelativeDuration) Set(val RelativeDuration) {
 	o.val = val
@@ -1364,6 +1382,9 @@ type OptionalDateDuration struct {
 func (o *OptionalDateDuration) Get() (DateDuration, bool) {
 	return o.val, o.isSet
 }
+
+// Value returns the value or the zero value if not set.
+func (o OptionalDateDuration) Value() DateDuration { return o.val }
 
 // Set sets the value.
 func (o *OptionalDateDuration) Set(val DateDuration) {

--- a/internal/edgedbtypes/memory.go
+++ b/internal/edgedbtypes/memory.go
@@ -107,6 +107,9 @@ type OptionalMemory struct {
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalMemory) Get() (Memory, bool) { return o.val, o.isSet }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalMemory) Value() Memory { return o.val }
+
 // Set sets the value.
 func (o *OptionalMemory) Set(val Memory) {
 	o.val = val

--- a/internal/edgedbtypes/numbers.go
+++ b/internal/edgedbtypes/numbers.go
@@ -59,6 +59,9 @@ type OptionalInt16 struct {
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalInt16) Get() (int16, bool) { return o.val, o.isSet }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalInt16) Value() int16 { return o.val }
+
 // Set sets the value.
 func (o *OptionalInt16) Set(val int16) {
 	o.val = val
@@ -112,6 +115,9 @@ type OptionalInt32 struct {
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalInt32) Get() (int32, bool) { return o.val, o.isSet }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalInt32) Value() int32 { return o.val }
+
 // Set sets the value.
 func (o *OptionalInt32) Set(val int32) {
 	o.val = val
@@ -164,6 +170,9 @@ type OptionalInt64 struct {
 
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalInt64) Get() (int64, bool) { return o.val, o.isSet }
+
+// Value returns the value or the zero value if not set.
+func (o OptionalInt64) Value() int64 { return o.val }
 
 // Set sets the value.
 func (o *OptionalInt64) Set(val int64) *OptionalInt64 {
@@ -220,6 +229,9 @@ type OptionalFloat32 struct {
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalFloat32) Get() (float32, bool) { return o.val, o.isSet }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalFloat32) Value() float32 { return o.val }
+
 // Set sets the value.
 func (o *OptionalFloat32) Set(val float32) {
 	o.val = val
@@ -272,6 +284,9 @@ type OptionalFloat64 struct {
 
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalFloat64) Get() (float64, bool) { return o.val, o.isSet }
+
+// Value returns the value or the zero value if not set.
+func (o OptionalFloat64) Value() float64 { return o.val }
 
 // Set sets the value.
 func (o *OptionalFloat64) Set(val float64) {

--- a/internal/edgedbtypes/numerics.go
+++ b/internal/edgedbtypes/numerics.go
@@ -39,6 +39,9 @@ type OptionalBigInt struct {
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalBigInt) Get() (*big.Int, bool) { return o.val, o.isSet }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalBigInt) Value() *big.Int { return o.val }
+
 // Set sets the value.
 func (o *OptionalBigInt) Set(val *big.Int) {
 	if val == nil {

--- a/internal/edgedbtypes/range.go
+++ b/internal/edgedbtypes/range.go
@@ -16,7 +16,9 @@
 
 package edgedbtypes
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 type emptyRangeJSON struct {
 	Empty bool `json:"empty"`
@@ -143,6 +145,9 @@ type OptionalRangeInt32 struct {
 func (o OptionalRangeInt32) Get() (RangeInt32, bool) {
 	return o.val, o.isSet
 }
+
+// Value returns the value or the zero value if not set.
+func (o OptionalRangeInt32) Value() RangeInt32 { return o.val }
 
 // Set sets the value.
 func (o *OptionalRangeInt32) Set(val RangeInt32) {
@@ -301,6 +306,9 @@ func (o OptionalRangeInt64) Get() (RangeInt64, bool) {
 	return o.val, o.isSet
 }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalRangeInt64) Value() RangeInt64 { return o.val }
+
 // Set sets the value.
 func (o *OptionalRangeInt64) Set(val RangeInt64) {
 	o.val = val
@@ -454,6 +462,9 @@ func NewOptionalRangeFloat32(v RangeFloat32) OptionalRangeFloat32 {
 func (o OptionalRangeFloat32) Get() (RangeFloat32, bool) {
 	return o.val, o.isSet
 }
+
+// Value returns the value or the zero value if not set.
+func (o OptionalRangeFloat32) Value() RangeFloat32 { return o.val }
 
 // Set sets the value.
 func (o *OptionalRangeFloat32) Set(val RangeFloat32) {
@@ -609,6 +620,9 @@ func (o OptionalRangeFloat64) Get() (RangeFloat64, bool) {
 	return o.val, o.isSet
 }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalRangeFloat64) Value() RangeFloat64 { return o.val }
+
 // Set sets the value.
 func (o *OptionalRangeFloat64) Set(val RangeFloat64) {
 	o.val = val
@@ -762,6 +776,9 @@ type OptionalRangeDateTime struct {
 func (o *OptionalRangeDateTime) Get() (RangeDateTime, bool) {
 	return o.val, o.isSet
 }
+
+// Value returns the value or the zero value if not set.
+func (o *OptionalRangeDateTime) Value() RangeDateTime { return o.val }
 
 // Set sets the value.
 func (o *OptionalRangeDateTime) Set(val RangeDateTime) {
@@ -919,6 +936,9 @@ func (o OptionalRangeLocalDateTime) Get() (RangeLocalDateTime, bool) {
 	return o.val, o.isSet
 }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalRangeLocalDateTime) Value() RangeLocalDateTime { return o.val }
+
 // Set sets the value.
 func (o *OptionalRangeLocalDateTime) Set(val RangeLocalDateTime) {
 	o.val = val
@@ -1075,6 +1095,9 @@ type OptionalRangeLocalDate struct {
 func (o OptionalRangeLocalDate) Get() (RangeLocalDate, bool) {
 	return o.val, o.isSet
 }
+
+// Value returns the value or the zero value if not set.
+func (o OptionalRangeLocalDate) Value() RangeLocalDate { return o.val }
 
 // Set sets the value.
 func (o *OptionalRangeLocalDate) Set(val RangeLocalDate) {

--- a/internal/edgedbtypes/str.go
+++ b/internal/edgedbtypes/str.go
@@ -38,6 +38,9 @@ type OptionalStr struct {
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalStr) Get() (string, bool) { return o.val, o.isSet }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalStr) Value() string { return o.val }
+
 // Set sets the value.
 func (o *OptionalStr) Set(val string) {
 	o.val = val

--- a/internal/edgedbtypes/uuid.go
+++ b/internal/edgedbtypes/uuid.go
@@ -96,6 +96,9 @@ type OptionalUUID struct {
 // Get returns the value and a boolean indicating if the value is present.
 func (o OptionalUUID) Get() (UUID, bool) { return o.val, o.isSet }
 
+// Value returns the value or the zero value if not set.
+func (o OptionalUUID) Value() UUID { return o.val }
+
 // Set sets the value.
 func (o *OptionalUUID) Set(val UUID) {
 	o.val = val

--- a/rstdocs/types.rst
+++ b/rstdocs/types.rst
@@ -576,6 +576,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalBigInt) Value() *big.Int
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalBool
 -------------------
 
@@ -659,6 +671,18 @@ UnmarshalJSON unmarshals bytes into \*o.
     func (o *OptionalBool) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalBool) Value() bool
+
+Value returns the value or the zero value if not set.
 
 
 
@@ -750,6 +774,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalBytes) Value() []byte
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalDateDuration
 ---------------------------
 
@@ -833,6 +869,18 @@ UnmarshalJSON unmarshals bytes into \*o.
     func (o *OptionalDateDuration) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalDateDuration) Value() DateDuration
+
+Value returns the value or the zero value if not set.
 
 
 
@@ -924,6 +972,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalDateTime) Value() time.Time
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalDuration
 -----------------------
 
@@ -1007,6 +1067,18 @@ UnmarshalJSON unmarshals bytes into \*o.
     func (o *OptionalDuration) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalDuration) Value() Duration
+
+Value returns the value or the zero value if not set.
 
 
 
@@ -1098,6 +1170,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalFloat32) Value() float32
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalFloat64
 ----------------------
 
@@ -1181,6 +1265,18 @@ UnmarshalJSON unmarshals bytes into \*o.
     func (o *OptionalFloat64) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalFloat64) Value() float64
+
+Value returns the value or the zero value if not set.
 
 
 
@@ -1272,6 +1368,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalInt16) Value() int16
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalInt32
 --------------------
 
@@ -1355,6 +1463,18 @@ UnmarshalJSON unmarshals bytes into \*o.
     func (o *OptionalInt32) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalInt32) Value() int32
+
+Value returns the value or the zero value if not set.
 
 
 
@@ -1446,6 +1566,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalInt64) Value() int64
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalLocalDate
 ------------------------
 
@@ -1529,6 +1661,18 @@ UnmarshalJSON unmarshals bytes into \*o.
     func (o *OptionalLocalDate) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalLocalDate) Value() LocalDate
+
+Value returns the value or the zero value if not set.
 
 
 
@@ -1620,6 +1764,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalLocalDateTime) Value() LocalDateTime
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalLocalTime
 ------------------------
 
@@ -1703,6 +1859,18 @@ UnmarshalJSON unmarshals bytes into \*o.
     func (o *OptionalLocalTime) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalLocalTime) Value() LocalTime
+
+Value returns the value or the zero value if not set.
 
 
 
@@ -1794,6 +1962,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalMemory) Value() Memory
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalRangeDateTime
 ----------------------------
 
@@ -1877,6 +2057,18 @@ UnmarshalJSON unmarshals bytes into \*o.
     func (o *OptionalRangeDateTime) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o *OptionalRangeDateTime) Value() RangeDateTime
+
+Value returns the value or the zero value if not set.
 
 
 
@@ -1968,6 +2160,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalRangeFloat32) Value() RangeFloat32
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalRangeFloat64
 ---------------------------
 
@@ -2051,6 +2255,18 @@ UnmarshalJSON unmarshals bytes into \*o.
     func (o *OptionalRangeFloat64) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalRangeFloat64) Value() RangeFloat64
+
+Value returns the value or the zero value if not set.
 
 
 
@@ -2142,6 +2358,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalRangeInt32) Value() RangeInt32
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalRangeInt64
 -------------------------
 
@@ -2229,6 +2457,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalRangeInt64) Value() RangeInt64
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalRangeLocalDate
 -----------------------------
 
@@ -2312,6 +2552,18 @@ UnmarshalJSON unmarshals bytes into \*o.
     func (o *OptionalRangeLocalDate) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalRangeLocalDate) Value() RangeLocalDate
+
+Value returns the value or the zero value if not set.
 
 
 
@@ -2405,6 +2657,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalRangeLocalDateTime) Value() RangeLocalDateTime
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalRelativeDuration
 -------------------------------
 
@@ -2488,6 +2752,18 @@ UnmarshalJSON unmarshals bytes into \*o.
     func (o *OptionalRelativeDuration) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalRelativeDuration) Value() RelativeDuration
+
+Value returns the value or the zero value if not set.
 
 
 
@@ -2579,6 +2855,18 @@ Unset marks the value as missing.
 
 
 
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalStr) Value() string
+
+Value returns the value or the zero value if not set.
+
+
+
+
 *type* OptionalUUID
 -------------------
 
@@ -2662,6 +2950,18 @@ UnmarshalJSON unmarshals bytes into \*o
     func (o *OptionalUUID) Unset()
 
 Unset marks the value as missing.
+
+
+
+
+*method* Value
+..............
+
+.. code-block:: go
+
+    func (o OptionalUUID) Value() UUID
+
+Value returns the value or the zero value if not set.
 
 
 


### PR DESCRIPTION
The Value() is like the Get() function except that it returns the  zero value when the option is not set.  This can make the optimal type easier to use in some scenarios.