### PR TITLE
Retry queries run with Execute()

### DIFF
--- a/client.go
+++ b/client.go
@@ -270,8 +270,7 @@ func (c *Client) ExecuteSQL(
 	return gel.FirstError(err, c.pool.Release(conn, err))
 }
 
-// Tx runs an action in a transaction retrying failed actions
-// if they might succeed on a subsequent attempt.
+// Tx runs a [geltypes.TxBlock] in a transaction retrying failed attempts.
 //
 // Retries are governed by retry rules.
 // The default rule can be set with WithRetryRule().

--- a/gelcfg/retryrule.go
+++ b/gelcfg/retryrule.go
@@ -45,8 +45,18 @@ func NewRetryRule() RetryRule {
 	}
 }
 
-// RetryRule determines how transactions should be retried when run in Tx()
-// methods. See Client.Tx() for details.
+// RetryRule determines how transactions or queries outside of transactions
+// should be retried.
+//
+// Retries are governed by retry rules.
+// The default rule can be set with [RetryOptions.WithDefault].
+// For more fine grained control a RetryRule can be set
+// for each defined RetryCondition using [RetryOptions.WithCondition].
+// When a transaction fails but [gelerr.Error.HasTag] [gelerr.ShouldRetry]
+// the rule for the failure condition is used to determine if the transaction
+// should be tried again based on [RetryRule.Attempts] and the amount of time
+// to wait before retrying is determined by [RetryRule.Backoff].
+// The default retry rule is 3 attempts and exponential backoff with jitter.
 type RetryRule struct {
 	// fromFactory indicates that a RetryOptions value was created using
 	// NewRetryOptions() and not created directly. Requiring users to use the

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,225 @@
+package gel
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/geldata/gel-go/geltypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func randomName() string {
+	return fmt.Sprintf("test%v", rand.Intn(10_000_000))
+}
+
+func assertRetry(
+	t *testing.T,
+	cb func(context.Context, string, string, int64, int64) error,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	err := client.Execute(ctx, `SELECT 1`)
+	require.NoError(t, err)
+
+	query := `
+		SELECT (
+			INSERT Counter {
+				name := <str>$0,
+				value := 1,
+			} UNLESS CONFLICT ON .name
+			ELSE (
+				UPDATE Counter
+				SET { value := .value + 1 }
+			)
+		).value
+		ORDER BY sys::_sleep(<int64>$1)
+		THEN <int64>$2
+	`
+
+	name := randomName()
+	errors := make(chan error, 3)
+
+	go func() {
+		errors <- cb(ctx, query, name, 0, 0)
+	}()
+
+	go func() {
+		errors <- cb(ctx, query, name, 5, 1)
+	}()
+
+	go func() {
+		errors <- cb(ctx, query, name, 5, 2)
+	}()
+
+	for i := 0; i < 3; i++ {
+		assert.NoError(t, <-errors)
+	}
+
+	var value int32
+	query = "SELECT (SELECT Counter FILTER .name = <str>$0).value"
+	err = client.QuerySingle(ctx, query, &value, name)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(3), value)
+}
+
+func TestRetryExecute(t *testing.T) {
+	assertRetry(t, func(
+		ctx context.Context,
+		query, name string,
+		sleep, nonce int64,
+	) error {
+		return client.Execute(ctx, query, name, sleep, nonce)
+	})
+}
+
+func TestRetryQuery(t *testing.T) {
+	assertRetry(t, func(
+		ctx context.Context,
+		query, name string,
+		sleep, nonce int64,
+	) error {
+		var value []int32
+		return client.Query(ctx, query, &value, name, sleep, nonce)
+	})
+}
+
+func TestRetryQueryJSON(t *testing.T) {
+	assertRetry(t, func(
+		ctx context.Context,
+		query, name string,
+		sleep, nonce int64,
+	) error {
+		var value []byte
+		return client.QueryJSON(ctx, query, &value, name, sleep, nonce)
+	})
+}
+
+func TestRetryQuerySingle(t *testing.T) {
+	assertRetry(t, func(
+		ctx context.Context,
+		query, name string,
+		sleep, nonce int64,
+	) error {
+		var value int32
+		return client.QuerySingle(ctx, query, &value, name, sleep, nonce)
+	})
+}
+
+func TestRetryQuerySingleJSON(t *testing.T) {
+	assertRetry(t, func(
+		ctx context.Context,
+		query, name string,
+		sleep, nonce int64,
+	) error {
+		var value []byte
+		return client.QuerySingleJSON(ctx, query, &value, name, sleep, nonce)
+	})
+}
+
+func assertRetryTx(
+	t *testing.T,
+	cb func(context.Context, geltypes.Tx, string, string) error,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	name := randomName()
+	iterMtx := sync.Mutex{}
+	iterations := 0
+	barrier := sync.WaitGroup{}
+	barrier.Add(2)
+	errors := make(chan error, 2)
+
+	for i := 0; i < 2; i++ {
+		go func() {
+			errors <- client.Tx(ctx, func(ctx context.Context, tx geltypes.Tx) error {
+				iterMtx.Lock()
+				iterations += 1
+				iterMtx.Unlock()
+
+				require.NoError(t, tx.Execute(ctx, "SELECT 1"))
+
+				barrier.Done()
+				barrier.Wait()
+
+				query := `
+					SELECT (
+						INSERT Counter {
+							name := <str>$0,
+							value := 1,
+						}
+						UNLESS CONFLICT ON .name
+						ELSE (
+							UPDATE Counter
+							SET { value := .value + 1 }
+						)
+					).value
+				`
+
+				err := cb(ctx, tx, query, name)
+				if err != nil {
+					barrier.Add(1)
+				}
+				return err
+			})
+		}()
+	}
+
+	for i := 0; i < 2; i++ {
+		require.NoError(t, <-errors)
+	}
+
+	assert.Equal(t, 3, iterations)
+
+	var value int32
+	query := "SELECT (SELECT Counter FILTER .name = <str>$0).value"
+	err := client.QuerySingle(ctx, query, &value, name)
+	assert.NoError(t, err)
+	assert.Equal(t, int32(2), value)
+}
+
+func TestRetryTxQuery(t *testing.T) {
+	assertRetryTx(
+		t,
+		func(ctx context.Context, tx geltypes.Tx, query, name string) error {
+			var value []int32
+			return tx.Query(ctx, query, &value, name)
+		},
+	)
+}
+
+func TestRetryTxQueryJSON(t *testing.T) {
+	assertRetryTx(
+		t,
+		func(ctx context.Context, tx geltypes.Tx, query, name string) error {
+			var value []byte
+			return tx.QueryJSON(ctx, query, &value, name)
+		},
+	)
+}
+
+func TestRetryTxQuerySingle(t *testing.T) {
+	assertRetryTx(
+		t,
+		func(ctx context.Context, tx geltypes.Tx, query, name string) error {
+			var value int32
+			return tx.QuerySingle(ctx, query, &value, name)
+		},
+	)
+}
+
+func TestRetryTxQuerySingleJSON(t *testing.T) {
+	assertRetryTx(
+		t,
+		func(ctx context.Context, tx geltypes.Tx, query, name string) error {
+			var value []byte
+			return tx.QuerySingleJSON(ctx, query, &value, name)
+		},
+	)
+}

--- a/retry_test.go
+++ b/retry_test.go
@@ -158,7 +158,7 @@ func assertRetryTx(
 				ctx,
 				func(ctx context.Context, tx geltypes.Tx) error {
 					iterMtx.Lock()
-					iterations += 1
+					iterations++
 					iterMtx.Unlock()
 
 					require.NoError(t, tx.Execute(ctx, "SELECT 1"))

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,3 +1,19 @@
+// This source file is part of the EdgeDB open source project.
+//
+// Copyright EdgeDB Inc. and the EdgeDB authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gel
 
 import (
@@ -138,17 +154,19 @@ func assertRetryTx(
 
 	for i := 0; i < 2; i++ {
 		go func() {
-			errors <- client.Tx(ctx, func(ctx context.Context, tx geltypes.Tx) error {
-				iterMtx.Lock()
-				iterations += 1
-				iterMtx.Unlock()
+			errors <- client.Tx(
+				ctx,
+				func(ctx context.Context, tx geltypes.Tx) error {
+					iterMtx.Lock()
+					iterations += 1
+					iterMtx.Unlock()
 
-				require.NoError(t, tx.Execute(ctx, "SELECT 1"))
+					require.NoError(t, tx.Execute(ctx, "SELECT 1"))
 
-				barrier.Done()
-				barrier.Wait()
+					barrier.Done()
+					barrier.Wait()
 
-				query := `
+					query := `
 					SELECT (
 						INSERT Counter {
 							name := <str>$0,
@@ -162,12 +180,13 @@ func assertRetryTx(
 					).value
 				`
 
-				err := cb(ctx, tx, query, name)
-				if err != nil {
-					barrier.Add(1)
-				}
-				return err
-			})
+					err := cb(ctx, tx, query, name)
+					if err != nil {
+						barrier.Add(1)
+					}
+					return err
+				},
+			)
 		}()
 	}
 

--- a/testserver_test.go
+++ b/testserver_test.go
@@ -88,59 +88,50 @@ func initServer() {
 	`)
 
 	log.Println("running migration")
-	if protocolVersion.GTE(gelint.ProtocolVersion1p0) {
-		execOrFatal(`
-			START MIGRATION TO {
-				module default {
-					global global_id -> uuid;
-					required global global_str -> str {
-						default := "default";
-					};
-					global global_bytes -> bytes;
-					global global_int16 -> int16;
-					global global_int32 -> int32;
-					global global_int64 -> int64;
-					global global_float32 -> float32;
-					global global_float64 -> float64;
-					global global_bool -> bool;
-					global global_datetime -> datetime;
-					global global_duration -> duration;
-					global global_json -> json;
-					global global_local_datetime -> cal::local_datetime;
-					global global_local_date -> cal::local_date;
-					global global_local_time -> cal::local_time;
-					global global_bigint -> bigint;
-					global global_relative_duration -> cal::relative_duration;
-					global global_date_duration -> cal::date_duration;
-					global global_memory -> cfg::memory;
+	execOrFatal(`
+		START MIGRATION TO {
+			module default {
+				global global_id -> uuid;
+				required global global_str -> str {
+					default := "default";
+				};
+				global global_bytes -> bytes;
+				global global_int16 -> int16;
+				global global_int32 -> int32;
+				global global_int64 -> int64;
+				global global_float32 -> float32;
+				global global_float64 -> float64;
+				global global_bool -> bool;
+				global global_datetime -> datetime;
+				global global_duration -> duration;
+				global global_json -> json;
+				global global_local_datetime -> cal::local_datetime;
+				global global_local_date -> cal::local_date;
+				global global_local_time -> cal::local_time;
+				global global_bigint -> bigint;
+				global global_relative_duration -> cal::relative_duration;
+				global global_date_duration -> cal::date_duration;
+				global global_memory -> cfg::memory;
 
-					type User {
-						property name -> str;
-					}
-					type TxTest {
-						required property name -> str;
+				type User {
+					property name -> str;
+				}
+				type TxTest {
+					required property name -> str;
+				}
+				type Counter {
+					name: str {
+						constraint exclusive;
+					};
+					value: int32 {
+						default := 0;
 					}
 				}
-			};
-			POPULATE MIGRATION;
-			COMMIT MIGRATION;
-		`)
-	} else {
-		execOrFatal(`
-			START MIGRATION TO {
-				module default {
-					type User {
-						property name -> str;
-					}
-					type TxTest {
-						required property name -> str;
-					}
-				}
-			};
-			POPULATE MIGRATION;
-			COMMIT MIGRATION;
-		`)
-	}
+			}
+		};
+		POPULATE MIGRATION;
+		COMMIT MIGRATION;
+	`)
 }
 
 func initClient() {

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
 	"strings"
 	"testing"
 
@@ -311,7 +310,7 @@ func TestSQLTx(t *testing.T) {
 }
 
 func selectInTx(t *testing.T, cb func(context.Context, geltypes.Tx, string)) {
-	name := fmt.Sprintf("test%v", rand.Intn(10_000_000))
+	name := randomName()
 	ctx := context.Background()
 	err := client.Tx(ctx, func(ctx context.Context, tx geltypes.Tx) error {
 		e := tx.Execute(ctx, "INSERT TxTest {name := <str>$0};", name)

--- a/tutorial_test.go
+++ b/tutorial_test.go
@@ -18,8 +18,6 @@ package gel
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 
 	"github.com/geldata/gel-go/gelcfg"
@@ -44,7 +42,7 @@ type Movie struct {
 
 func TestTutorial(t *testing.T) {
 	ctx := context.Background()
-	dbName := fmt.Sprintf("test%v", rand.Intn(10_000))
+	dbName := randomName()
 	err := client.Execute(ctx, "CREATE DATABASE "+dbName)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Previously queries run with any method except for Execute() were automatically retried. Now queries run with Execute() are also retried.

Fixes https://github.com/geldata/gel-go/issues/333