### PR TITLE
Move documentation examples into Example functions

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,6 +43,9 @@ func CreateClient(opts gelcfg.Options) (*Client, error) { // nolint:gocritic,lll
 //
 // dsn is either an instance name or a [DSN].
 //
+//	dsn := "gel://admin@localhost/main"
+//	client, err := gel.CreateClientDSN(dsn, opts)
+//
 // [DSN]: https://docs.geldata.com/reference/reference/dsn#ref-dsn
 func CreateClientDSN(dsn string, opts gelcfg.Options) (*Client, error) { // nolint:gocritic,lll
 	pool, err := gel.NewPool(dsn, opts)

--- a/cmd/edgeql-go/endtoend_test.go
+++ b/cmd/edgeql-go/endtoend_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -64,19 +63,7 @@ var tests = []struct {
 
 func TestMain(m *testing.M) {
 	o := testserver.Options()
-	pwd, ok := o.Password.Get()
-	if !ok {
-		log.Fatal("missing password")
-	}
-	dsn = fmt.Sprintf(
-		"edgedb://%s:%s@%s:%d?tls_security=%s&tls_ca_file=%s",
-		o.User,
-		pwd,
-		o.Host,
-		o.Port,
-		o.TLSOptions.SecurityMode,
-		o.TLSOptions.CAFile,
-	)
+	dsn = testserver.AsDSN(o)
 	os.Exit(m.Run())
 }
 

--- a/doc.go
+++ b/doc.go
@@ -18,56 +18,10 @@
 // [github.com/geldata/gel-go/cmd/edgeql-go] is a code generator that
 // generates go functions from edgeql files.
 //
-// Typical client usage looks like this:
-//
-//	package main
-//
-//	import (
-//	    "context"
-//	    "log"
-//
-//	    "github.com/geldata/gel-go"
-//	    "github.com/geldata/gel-go/gelcfg"
-//	)
-//
-//	func main() {
-//	    ctx := context.Background()
-//	    client, err := gel.CreateClient(gelcfg.Options{})
-//	    if err != nil {
-//	        log.Fatal(err)
-//	    }
-//	    defer client.Close()
-//
-//	    var (
-//	        age   int64 = 21
-//	        users []struct {
-//	            ID   geltypes.UUID `gel:"id"`
-//	            Name string   `gel:"name"`
-//	        }
-//	    )
-//
-//	    query := "SELECT User{name} FILTER .age = <int64>$0"
-//	    err = client.Query(ctx, query, &users, age)
-//	    ...
-//	}
+// See [Client] for an example of typical usage.
 //
 // We recommend using environment variables for connection parameters. See the
 // [client connection docs] for more information.
-//
-// You may also connect to a database using a DSN:
-//
-//	dsn := "gel://admin@localhost/main"
-//	client, err := gel.CreateClientDSN(dsn, opts)
-//
-// Or you can use Option fields.
-//
-//	opts := gelcfg.Options{
-//	    Branch:      "main",
-//	    User:        "admin",
-//	    Concurrency: 4,
-//	}
-//
-//	client, err := gel.CreateClient(opts)
 //
 // # Errors
 //
@@ -128,29 +82,15 @@
 // one directly to the other.
 //
 // Shape fields that are not required must use optional types for receiving
-// query results. The [gelcfg.Optional] struct can be embedded to make structs
+// query results. [geltypes.Optional] can be embedded to make structs
 // optional.
-//
-//	type User struct {
-//	    gelcfg.Optional
-//	    Email string `gel:"email"`
-//	}
-//
-//	var result User
-//	err := client.QuerySingle(ctx, `SELECT User { email } LIMIT 0`, $result)
-//	fmt.Println(result.Missing())
-//	// Output: true
-//
-//	err := client.QuerySingle(ctx, `SELECT User { email } LIMIT 1`, $result)
-//	fmt.Println(result.Missing())
-//	// Output: false
 //
 // Not all types listed above are valid query parameters.  To pass a slice of
 // scalar values use array in your query. Gel doesn't currently support
 // using sets as parameters.
 //
 //	query := `select User filter .id in array_unpack(<array<uuid>>$1)`
-//	client.QuerySingle(ctx, query, $user, []geltypes.UUID{...})
+//	client.QuerySingle(ctx, query, &user, []geltypes.UUID{...})
 //
 // Nested structures are also not directly allowed but you can use [json]
 // instead.

--- a/example_test.go
+++ b/example_test.go
@@ -18,12 +18,10 @@ package gel_test
 
 import (
 	"context"
-	"errors"
 	"log"
 
 	gel "github.com/geldata/gel-go"
 	"github.com/geldata/gel-go/gelcfg"
-	"github.com/geldata/gel-go/gelerr"
 	"github.com/geldata/gel-go/geltypes"
 	"github.com/geldata/gel-go/internal/testserver"
 )
@@ -38,29 +36,10 @@ var (
 	id     geltypes.UUID
 )
 
-func isDuplicateDatabaseDefinitionError(err error) bool {
-	var gelErr gelerr.Error
-	return errors.As(err, &gelErr) &&
-		gelErr.Category(gelerr.DuplicateDatabaseDefinitionError)
-}
-
 func init() {
 	ctx = context.Background()
-
 	opts = testserver.Options()
 	var err error
-	client, err = gel.CreateClient(opts)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = client.Execute(ctx, "create empty branch examples")
-	if err != nil && !isDuplicateDatabaseDefinitionError(err) {
-		log.Fatal(err)
-	}
-
-	opts.Database = ""
-	opts.Branch = "examples"
 	client, err = gel.CreateClient(opts)
 	if err != nil {
 		log.Fatal(err)

--- a/gelcfg/main_test.go
+++ b/gelcfg/main_test.go
@@ -18,6 +18,7 @@ package gelcfg_test
 
 import (
 	"context"
+	"log"
 	"os"
 	"testing"
 
@@ -34,6 +35,10 @@ var (
 func TestMain(m *testing.M) {
 	ctx = context.Background()
 	opts := testserver.Options()
-	os.Setenv("GEL_DSN", testserver.AsDSN(opts))
+	err := os.Setenv("GEL_DSN", testserver.AsDSN(opts))
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	m.Run()
 }

--- a/gelcfg/main_test.go
+++ b/gelcfg/main_test.go
@@ -1,0 +1,39 @@
+// This source file is part of the Gel open source project.
+//
+// Copyright Gel Data Inc. and the Gel authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gelcfg_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/geldata/gel-go/internal/testserver"
+)
+
+var (
+	// Define identifiers that are used in examples, but keep them in their own
+	// file. This way the definition is not included in the example. This keeps
+	// examples concise.
+	ctx context.Context
+)
+
+func TestMain(m *testing.M) {
+	ctx = context.Background()
+	opts := testserver.Options()
+	os.Setenv("GEL_DSN", testserver.AsDSN(opts))
+	m.Run()
+}

--- a/gelcfg/options_test.go
+++ b/gelcfg/options_test.go
@@ -1,0 +1,32 @@
+package gelcfg_test
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/geldata/gel-go"
+	"github.com/geldata/gel-go/gelcfg"
+)
+
+func ExampleOptions() {
+	opts := gelcfg.Options{
+		ConnectTimeout:     60 * time.Second,
+		WaitUntilAvailable: 5 * time.Second,
+		WarningHandler:     gelcfg.WarningsAsErrors,
+	}
+
+	client, err := gel.CreateClient(opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var message string
+	err = client.QuerySingle(ctx, `SELECT "hello Gel"`, &message)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(message)
+	// Output: hello Gel
+}

--- a/gelcfg/options_test.go
+++ b/gelcfg/options_test.go
@@ -1,3 +1,19 @@
+// This source file is part of the Gel open source project.
+//
+// Copyright Gel Data Inc. and the Gel authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gelcfg_test
 
 import (

--- a/geltypes/example_test.go
+++ b/geltypes/example_test.go
@@ -1,0 +1,37 @@
+package geltypes_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/geldata/gel-go/geltypes"
+)
+
+func ExampleOptional() {
+	type User struct {
+		geltypes.Optional
+		Name string `gel:"name"`
+	}
+
+	var result User
+	query := `
+		SELECT User { name }
+		FILTER .name = "doesn't exist"
+		LIMIT 1
+	`
+	err := client.QuerySingle(ctx, query, &result)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(result.Missing())
+
+	err = client.QuerySingle(ctx, `SELECT User { name } LIMIT 1`, &result)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(result.Missing())
+
+	// Output:
+	// true
+	// false
+}

--- a/geltypes/example_test.go
+++ b/geltypes/example_test.go
@@ -1,3 +1,19 @@
+// This source file is part of the Gel open source project.
+//
+// Copyright Gel Data Inc. and the Gel authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package geltypes_test
 
 import (

--- a/geltypes/main_test.go
+++ b/geltypes/main_test.go
@@ -1,0 +1,51 @@
+package geltypes_test
+
+import (
+	"context"
+	"log"
+	"testing"
+
+	"github.com/geldata/gel-go"
+	"github.com/geldata/gel-go/internal/testserver"
+)
+
+var (
+	// Define identifiers that are used in examples, but keep them in their own
+	// file. This way the definition is not included in the example. This keeps
+	// examples concise.
+	ctx    context.Context
+	client *gel.Client
+)
+
+func TestMain(m *testing.M) {
+	ctx = context.Background()
+	opts := testserver.Options()
+
+	var err error
+	client, err = gel.CreateClient(opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = client.Execute(ctx, `
+		START MIGRATION TO {
+			module default {
+				type User {
+					required name: str {
+						default := 'default';
+					};
+				};
+				type Product {};
+			}
+		};
+		POPULATE MIGRATION;
+		COMMIT MIGRATION;
+
+		INSERT User { name := 'Stephanie' };
+	`)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	m.Run()
+}

--- a/geltypes/main_test.go
+++ b/geltypes/main_test.go
@@ -1,3 +1,19 @@
+// This source file is part of the Gel open source project.
+//
+// Copyright Gel Data Inc. and the Gel authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package geltypes_test
 
 import (

--- a/geltypes/numbers.go
+++ b/geltypes/numbers.go
@@ -21,12 +21,7 @@ import (
 )
 
 // Optional represents a shape field that is not required.
-// Optional is embedded in structs to make them optional. For example:
-//
-//	type User struct {
-//	    geltypes.Optional
-//	    Name string `gel:"name"`
-//	}
+// Optional is embedded in structs to make them optional.
 type Optional struct {
 	isSet bool
 }

--- a/internal/testserver/server.go
+++ b/internal/testserver/server.go
@@ -68,7 +68,7 @@ func (i *info) options() gelcfg.Options {
 }
 
 // AsDSN returns a dsn string built from o.
-func AsDSN(o gelcfg.Options) string {
+func AsDSN(o gelcfg.Options) string { //nolint:gocritic
 	pwd, ok := o.Password.Get()
 	if ok {
 		pwd = ":" + pwd


### PR DESCRIPTION
This makes it so the examples are compiled and run with the test suite.

fixes https://github.com/geldata/gel-go/issues/362

To preview the generated docs run the following in the project root with this branch checked out.
```bash
go run golang.org/x/pkgsite/cmd/pkgsite@latest
```