### PR TITLE
Skip ExampleClient_WithTxOptions for now

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -34,8 +34,6 @@ func ExampleClient_WithTxOptions() {
 		return tx.Execute(ctx, "INSERT User")
 	})
 	fmt.Println(err)
-	// Output:
-	// gel.TransactionError: cannot execute SELECT in a read-only transaction
 }
 
 func ExampleClient_WithRetryOptions() {


### PR DESCRIPTION
The stable and nightly server versions return different error messages which breaks this example. Don't validate the output until the new error message is in stable.