### PR TITLE
Fix local dev issues when reusing the same gel server

### DIFF
--- a/options_test.go
+++ b/options_test.go
@@ -70,10 +70,11 @@ func ExampleClient_WithQueryTag() {
 	err = client.QuerySingle(
 		ctx,
 		`
-	SELECT assert_single((
+	SELECT (
 		SELECT sys::QueryStats
 		FILTER .tag = <str>$0
-	)).query
+		LIMIT 1
+	).query
 	`,
 		&query,
 		tag,

--- a/testserver_test.go
+++ b/testserver_test.go
@@ -61,10 +61,7 @@ func initServer() {
 		};
 	`)
 	if err != nil &&
-		strings.Contains(err.Error(), "'user_with_password' already exists") {
-		// The server was initialized in a previous test run.
-		return
-	} else if err != nil {
+		!strings.Contains(err.Error(), "'user_with_password' already exists") {
 		testserver.Fatal(err)
 	}
 	execOrFatal(`


### PR DESCRIPTION
Local dev has the option to reuse the same gel server for multiple test runs to save time. This is a fix for a couple issues in that workflow.