### PR TITLE
Accept null branch & database in credentials files

### DIFF
--- a/internal/client/connutils.go
+++ b/internal/client/connutils.go
@@ -133,7 +133,7 @@ type configResolver struct {
 	host               cfgVal // string
 	port               cfgVal // int
 	database           cfgVal // string
-	branch             cfgVal //string
+	branch             cfgVal // string
 	user               cfgVal // string
 	password           cfgVal // OptionalStr
 	tlsCAData          cfgVal // []byte
@@ -1695,7 +1695,13 @@ func (r *configResolver) parseCloudInstanceNameIntoConfig(
 
 	if r.secretKey.val == nil {
 		if name, key, ok := lookupGelOrEdgedbEnv("_SECRET_KEY"); ok {
-			r.setSecretKey(key, fmt.Sprintf("%s environment variable", name))
+			err := r.setSecretKey(
+				key,
+				fmt.Sprintf("%s environment variable", name),
+			)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/client/connutils.go
+++ b/internal/client/connutils.go
@@ -133,6 +133,7 @@ type configResolver struct {
 	host               cfgVal // string
 	port               cfgVal // int
 	database           cfgVal // string
+	branch             cfgVal //string
 	user               cfgVal // string
 	password           cfgVal // OptionalStr
 	tlsCAData          cfgVal // []byte
@@ -219,6 +220,19 @@ func (r *configResolver) setDatabase(val, source string) error {
 		return errors.New(`invalid database name: ""`)
 	}
 	r.database = cfgVal{val: val, source: source}
+	return nil
+}
+
+func (r *configResolver) setBranch(val, source string) error {
+	if r.branch.val != nil {
+		return nil
+	}
+
+	if val == "" {
+		return errors.New(`invalid branch name: ""`)
+	}
+
+	r.branch = cfgVal{val: val, source: source}
 	return nil
 }
 
@@ -351,17 +365,23 @@ func (r *configResolver) resolveOptions(
 	}
 
 	if opts.Database != "" {
-		e := r.setDatabase(
-			opts.Database,
-			"Database options",
-		)
-		if e != nil {
+		source := "Database options"
+		if e := r.setDatabase(opts.Database, source); e != nil {
 			return e
+		}
+		if opts.Branch == "" {
+			if e := r.setBranch(opts.Database, source); e != nil {
+				return e
+			}
 		}
 	}
 
 	if opts.Branch != "" {
-		if e := r.setDatabase(opts.Branch, "Branch options"); e != nil {
+		source := "Branch options"
+		if e := r.setBranch(opts.Branch, source); e != nil {
+			return e
+		}
+		if e := r.setDatabase(opts.Branch, source); e != nil {
 			return e
 		}
 	}
@@ -534,7 +554,7 @@ func (r *configResolver) resolveDSN(
 			return err
 		} else if val.val != nil {
 			br := strings.TrimPrefix(val.val.(string), "/")
-			if e := r.setDatabase(br, source+val.source); e != nil {
+			if e := r.setBranch(br, source+val.source); e != nil {
 				return e
 			}
 		}
@@ -545,7 +565,7 @@ func (r *configResolver) resolveDSN(
 			return err
 		} else if val.val != nil {
 			db := strings.TrimPrefix(val.val.(string), "/")
-			if e := r.setDatabase(db, source+val.source); e != nil {
+			if e := r.setBranch(db, source+val.source); e != nil {
 				return e
 			}
 		}
@@ -744,13 +764,15 @@ func (r *configResolver) applyCredentials(
 	}
 
 	if br, ok := creds.branch.Get(); ok && br != "" {
-		if e := r.setDatabase(br, source); e != nil {
+		if e := r.setBranch(br, source); e != nil {
 			return e
 		}
 	}
 
-	if e := r.setUser(creds.user, source); e != nil {
-		return e
+	if user, ok := creds.user.Get(); ok && user != "" {
+		if e := r.setUser(user, source); e != nil {
+			return e
+		}
 	}
 
 	if pwd, ok := creds.password.Get(); ok {
@@ -767,13 +789,25 @@ func (r *configResolver) applyCredentials(
 		}
 	}
 
+	if key, ok := creds.secretKey.Get(); ok {
+		if e := r.setSecretKey(key, source); e != nil {
+			return e
+		}
+	}
+
 	return nil
 }
 
 func (r *configResolver) resolveEnvVars(paths *cfgPaths) (bool, error) {
 	db, dbOk := os.LookupEnv("EDGEDB_DATABASE")
 	if dbOk {
-		err := r.setDatabase(db, "EDGEDB_DATABASE environment variable")
+		source := "EDGEDB_DATABASE environment variable"
+		err := r.setDatabase(db, source)
+		if err != nil {
+			return false, err
+		}
+
+		err = r.setBranch(db, source)
 		if err != nil {
 			return false, err
 		}
@@ -788,10 +822,13 @@ func (r *configResolver) resolveEnvVars(paths *cfgPaths) (bool, error) {
 				branchEnvVarName,
 			)
 		}
-		err := r.setDatabase(
-			branch,
-			fmt.Sprintf("%s environment variable", branchEnvVarName),
-		)
+		source := fmt.Sprintf("%s environment variable", branchEnvVarName)
+		err := r.setBranch(branch, source)
+		if err != nil {
+			return false, err
+		}
+
+		err = r.setDatabase(branch, source)
 		if err != nil {
 			return false, err
 		}
@@ -1005,6 +1042,7 @@ func (r *configResolver) resolveTOML(paths *cfgPaths) error {
 	)
 }
 
+// Returns envvar name and value if found.
 func lookupGelOrEdgedbEnv(name string) (string, string, bool) {
 	gelName := fmt.Sprintf("GEL%s", name)
 	edbName := fmt.Sprintf("EDGEDB%s", name)
@@ -1038,11 +1076,20 @@ func (r *configResolver) config(opts *gelcfg.Options) (*connConfig, error) {
 		port = r.port.val.(int)
 	}
 
-	database := "edgedb"
 	branch := "__default__"
+	database := "edgedb"
+	if r.branch.val != nil {
+		branch = r.branch.val.(string)
+		if r.database.val == nil {
+			database = branch
+		}
+	}
+
 	if r.database.val != nil {
 		database = r.database.val.(string)
-		branch = database
+		if r.branch.val == nil && database != "edgedb" {
+			branch = database
+		}
 	}
 
 	user := "edgedb"
@@ -1332,7 +1379,7 @@ func parseDSN(dsn string) (*url.URL, map[string]string, error) {
 	}
 
 	db := strings.TrimPrefix(uri.Path, "/")
-	if e := validateQueryArg(vals, "database", db); e != nil {
+	if e := validateQueryArg(vals, "branch", db); e != nil {
 		return nil, nil, e
 	}
 
@@ -1644,6 +1691,12 @@ func (r *configResolver) parseCloudInstanceNameIntoConfig(
 				" cannot exceed %d characters: %s/%s",
 			domainLabelMaxLength-1, org, inst,
 		)
+	}
+
+	if r.secretKey.val == nil {
+		if name, key, ok := lookupGelOrEdgedbEnv("_SECRET_KEY"); ok {
+			r.setSecretKey(key, fmt.Sprintf("%s environment variable", name))
+		}
 	}
 
 	var secretKey string

--- a/internal/client/connutils_test.go
+++ b/internal/client/connutils_test.go
@@ -431,7 +431,7 @@ var testcaseErrorMapping = map[string]string{
 	"invalid_port":                 "invalid port",
 	"invalid_host":                 "invalid host",
 	"invalid_user":                 "invalid user",
-	"invalid_database":             "invalid database",
+	"invalid_database":             "invalid database|invalid branch",
 	"exclusive_options":            "mutually exclusive options",
 	"multiple_compound_opts":       "mutually exclusive connection options",
 	"multiple_compound_env":        "mutually exclusive environment variables",

--- a/internal/client/credentials.go
+++ b/internal/client/credentials.go
@@ -31,12 +31,13 @@ import (
 type credentials struct {
 	host        types.OptionalStr
 	port        types.OptionalInt32
-	user        string
+	user        types.OptionalStr
 	database    types.OptionalStr
 	branch      types.OptionalStr
 	password    types.OptionalStr
 	ca          types.OptionalBytes
 	tlsSecurity types.OptionalStr
+	secretKey   types.OptionalStr
 }
 
 func readCredentials(path string) (*credentials, error) {
@@ -92,11 +93,11 @@ func validateCredentials(data map[string]interface{}) (*credentials, error) {
 	}
 
 	if user, ok := data["user"]; ok {
-		if result.user, ok = user.(string); !ok {
+		str, ok := user.(string)
+		if !ok {
 			return nil, errors.New("`user` must be a string")
 		}
-	} else {
-		return nil, errors.New("`user` key is required")
+		result.user.Set(str)
 	}
 
 	if host, ok := data["host"]; ok && host != "" {
@@ -108,10 +109,13 @@ func validateCredentials(data map[string]interface{}) (*credentials, error) {
 	}
 
 	if inMap("database", data) &&
-		inMap("branch", data) &&
-		data["database"] != data["branch"] {
-		return nil, errors.New(
-			"`database` and `branch` are both set but do not match")
+		inMap("branch", data) {
+		if data["database"] == "edgedb" && data["branch"] == "__default__" {
+			// this is valid
+		} else if data["database"] != data["branch"] {
+			return nil, errors.New(
+				"`database` and `branch` are both set but do not match")
+		}
 	}
 
 	if database, ok := data["database"]; ok {
@@ -136,6 +140,15 @@ func validateCredentials(data map[string]interface{}) (*credentials, error) {
 			return nil, errors.New("`password` must be a string")
 		}
 		result.password.Set(pwd)
+	}
+
+	if key, ok := data["secret_key"]; ok && key != nil {
+		str, ok := key.(string)
+		if !ok {
+			return nil, errors.New("`secret_key` must be a string")
+		}
+
+		result.secretKey.Set(str)
 	}
 
 	if ca, ok := data["tls_ca"]; ok {

--- a/internal/client/credentials.go
+++ b/internal/client/credentials.go
@@ -110,9 +110,9 @@ func validateCredentials(data map[string]interface{}) (*credentials, error) {
 
 	if inMap("database", data) &&
 		inMap("branch", data) {
-		if data["database"] == "edgedb" && data["branch"] == "__default__" {
-			// this is valid
-		} else if data["database"] != data["branch"] {
+		if data["database"] != data["branch"] &&
+			data["database"] != "edgedb" &&
+			data["branch"] != "__default__" {
 			return nil, errors.New(
 				"`database` and `branch` are both set but do not match")
 		}

--- a/internal/client/credentials_test.go
+++ b/internal/client/credentials_test.go
@@ -32,16 +32,10 @@ func TestCredentialsRead(t *testing.T) {
 		database: types.NewOptionalStr("test3n"),
 		password: types.NewOptionalStr("lZTBy1RVCfOpBAOwSCwIyBIR"),
 		port:     types.NewOptionalInt32(10702),
-		user:     "test3n",
+		user:     types.NewOptionalStr("test3n"),
 	}
 
 	assert.Equal(t, expected, creds)
-}
-
-func TestCredentialsEmpty(t *testing.T) {
-	creds, err := validateCredentials(map[string]interface{}{})
-	assert.EqualError(t, err, "`user` key is required")
-	assert.Nil(t, creds)
 }
 
 func TestCredentialsPort(t *testing.T) {


### PR DESCRIPTION
The gel CLI recently started writing credentials files that use `null` to indicate that the default branch and/or database name should be used instead of specifying a value explicitly. This caused the following error in gel-go.

```
`database` must be a string
```

Closes #382