### PR TITLE
Allow TLSOptions.ServerName use with TLSOptions.SecurityMode

### DIFF
--- a/internal/client/connutils.go
+++ b/internal/client/connutils.go
@@ -451,18 +451,17 @@ func (r *configResolver) resolveOptions(
 			"TLSOptions.SecurityMode option")
 	}
 
-	if opts.TLSOptions.ServerName != "" {
-		secSources = append(secSources, "TLSOptions.ServerName")
-		err = r.setTLSServerName(
-			opts.TLSOptions.ServerName,
-			"TLSOptions.ServerName options",
-		)
-	}
-
 	if len(secSources) > 1 {
 		return fmt.Errorf(
 			"mutually exclusive options set in Options: %v",
 			englishList(secSources, "and"))
+	}
+
+	if opts.TLSOptions.ServerName != "" {
+		err = r.setTLSServerName(
+			opts.TLSOptions.ServerName,
+			"TLSOptions.ServerName options",
+		)
 	}
 
 	if opts.SecretKey != "" {


### PR DESCRIPTION
The `insecure` TLS mode could be used together with `TLSServerName`, which is useful if the Gel server is running in tenant host mode and uses SNI to route traffic to the correct tenant